### PR TITLE
Unit Denies + Creep Last Hits + Item Sold

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,22 +13,22 @@
     "build:defs": "ts-node scripts/dev"
   },
   "dependencies": {
-    "w3ts": "^2.1.3"
+    "w3ts": "^2.2.1"
   },
   "devDependencies": {
     "@types/fs-extra": "^8.1.1",
-    "@types/node": "^12.19.1",
+    "@types/node": "^12.19.12",
     "@types/pako": "^1.0.1",
     "fs-extra": "^8.1.0",
     "lua-types": "^2.8.0",
     "luamin": "^1.0.4",
-    "mdx-m3-viewer": "^5.0.12",
+    "mdx-m3-viewer": "^5.2.3",
     "npm-watch": "^0.6.0",
     "ts-node": "^8.10.2",
     "tsconfig-paths": "^3.9.0",
-    "tsutils": "^3.17.1",
-    "typescript": "^4.0.5",
-    "typescript-to-lua": "^0.36.0",
+    "tsutils": "^3.19.0",
+    "typescript": "^4.1.3",
+    "typescript-to-lua": "^0.36.1",
     "war3-transformer": "^2.0.0",
     "war3-types": "^1.0.4",
     "war3tstlhelper": "^1.0.1",

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,9 @@
-import { MapPlayer } from "w3ts/handles/player";
-import { Camera } from "w3ts/handles/camera";
-import { getElapsedTime } from "w3ts/system/gametime";
-import { File } from "w3ts/system/file";
+import { Players } from "w3ts/globals";
+import { Camera, Group, Item, MapPlayer, TextTag, Trigger, Unit } from "w3ts/handles";
 import { addScriptHook, W3TS_HOOK } from "w3ts/hooks";
+import { File } from "w3ts/system/file";
+import { getElapsedTime } from "w3ts/system/gametime";
+import { playerColors } from "w3ts/utils/color";
 
 function init() {
   enableCameraZoom();
@@ -13,13 +14,13 @@ function init() {
 }
 
 function enableBadPing() {
-  let badPingTrigger = CreateTrigger();
-  let players = [];
+  const t = new Trigger();
+  const players = [];
   let playerCount = 0;
   for (let i = 0; i < bj_MAX_PLAYERS; i++) {
     if (GetPlayerSlotState(Player(i)) == PLAYER_SLOT_STATE_PLAYING) {
       playerCount++;
-      TriggerRegisterPlayerChatEvent(badPingTrigger, Player(i), "-badping", false);
+      t.registerPlayerChatEvent(Players[i], "-badping", false);
       DisplayTextToPlayer(Player(i), 0, 0, `|cff00ff00[W3C]:|r To cancel this game due to bad ping, all players must use|cffffff00 -badping|r.\nThis command expires in 2 minutes.`);
     }
   }
@@ -33,8 +34,8 @@ function enableBadPing() {
     requiredPlayers = 6;
   }
 
-  TriggerAddAction(badPingTrigger, () => {
-    let triggerPlayer = MapPlayer.fromEvent();
+  t.addAction(() => {
+    const triggerPlayer = MapPlayer.fromEvent();
 
     if (getElapsedTime() > 120) {
       DisplayTextToPlayer(triggerPlayer.handle, 0, 0, `|cff00ff00[W3C]:|r The|cffffff00 -badping|r command is disabled after two minutes of gameplay.`);
@@ -61,10 +62,10 @@ function enableBadPing() {
 }
 
 function enableCameraZoom() {
-  let zoomTrigger = CreateTrigger();
+  const t = new Trigger();
 
   for (let i = 0; i < bj_MAX_PLAYERS; i++) {
-    let isLocalPlayer = MapPlayer.fromHandle(Player(i)).name == MapPlayer.fromLocal().name;
+    const isLocalPlayer = MapPlayer.fromHandle(Player(i)).name == MapPlayer.fromLocal().name;
 
     // If the player is an observer, we will set a static zoom level.
     // As of right now, observer chat events are not picked up by the ChatEvent hook from above.
@@ -79,32 +80,32 @@ function enableCameraZoom() {
       const fileText = File.read("w3cZoomFFA.txt");
 
       if (fileText && Number(fileText) > 0) {
-        setCameraZoom(Number(fileText), MapPlayer.fromLocal().handle);
+        setCameraZoom(Number(fileText), MapPlayer.fromLocal());
       } else {
         print("\n");
         print("|cff00ff00[W3C] Tip:|r Type|cffffff00 -zoom <VALUE>|r to change your zoom level. Default: 1650 \n Minimum zoom: 1650 | Maximum zoom: 3000");
       }
     }
-    TriggerRegisterPlayerChatEvent(zoomTrigger, Player(i), "-zoom", false);
+    t.registerPlayerChatEvent(Players[i], "-zoom", false);
   }
 
-  TriggerAddAction(zoomTrigger, () => {
-    let triggerPlayer = MapPlayer.fromEvent();
-    let localPlayer = MapPlayer.fromLocal();;
+  t.addAction(() => {
+    const triggerPlayer = MapPlayer.fromEvent();
+    const localPlayer = MapPlayer.fromLocal();
 
     // Making sure that we only set our zoom level only if the local player is the one who called the command
     if (triggerPlayer.name != localPlayer.name) {
       return;
     }
 
-    let zoomLevel = GetEventPlayerChatString().split('-zoom')[1].trim();
-    let zoomNumber: number = Number(zoomLevel);
-    setCameraZoom(zoomNumber, triggerPlayer.handle);
+    const zoomLevel = GetEventPlayerChatString().split('-zoom')[1].trim();
+    const zoomNumber: number = Number(zoomLevel);
+    setCameraZoom(zoomNumber, triggerPlayer);
     File.write("w3cZoomFFA.txt", zoomNumber.toString());
-  });
+  })
 }
 
-function setCameraZoom(zoomLevel: number, player: player) {
+function setCameraZoom(zoomLevel: number, player: MapPlayer) {
   const maxZoom = 3000;
   const minZoom = 1650;
 
@@ -114,109 +115,95 @@ function setCameraZoom(zoomLevel: number, player: player) {
     zoomLevel = minZoom;
   }
 
-  if (player == MapPlayer.fromLocal().handle) {
-    DisplayTextToPlayer(player, 0, 0, `|cff00ff00[W3C]:|r Zoom is set to|cffffff00 ${zoomLevel}|r.`);
+  if (player == MapPlayer.fromLocal()) {
+    DisplayTextToPlayer(player.handle, 0, 0, `|cff00ff00[W3C]:|r Zoom is set to|cffffff00 ${zoomLevel}|r.`);
     Camera.setField(CAMERA_FIELD_TARGET_DISTANCE, zoomLevel, 0.0);
   }
 }
 
-addScriptHook(W3TS_HOOK.MAIN_AFTER, init);
-
-function getPlayerRGBCode(whichPlayer: player) {
-  if      (GetPlayerColor(whichPlayer) == PLAYER_COLOR_RED)        return [100.00, 1.18, 1.18]
-  else if (GetPlayerColor(whichPlayer) == PLAYER_COLOR_BLUE)       return [0.00, 25.88, 100.00]
-  else if (GetPlayerColor(whichPlayer) == PLAYER_COLOR_CYAN)       return [10.59, 90.59, 72.94]
-  else if (GetPlayerColor(whichPlayer) == PLAYER_COLOR_PURPLE)     return [33.33, 0.00, 50.59]
-  else if (GetPlayerColor(whichPlayer) == PLAYER_COLOR_YELLOW)     return [99.61, 98.82, 0.00]
-  else if (GetPlayerColor(whichPlayer) == PLAYER_COLOR_ORANGE)     return [99.61, 53.73, 5.10]
-  else if (GetPlayerColor(whichPlayer) == PLAYER_COLOR_GREEN)      return [12.94, 74.90, 0.00]
-  else if (GetPlayerColor(whichPlayer) == PLAYER_COLOR_PINK)       return [89.41, 36.08, 68.63]
-  else if (GetPlayerColor(whichPlayer) == PLAYER_COLOR_LIGHT_GRAY) return [57.65, 58.43, 58.82]
-  else if (GetPlayerColor(whichPlayer) == PLAYER_COLOR_LIGHT_BLUE) return [49.41, 74.90, 94.51]
-  else if (GetPlayerColor(whichPlayer) == PLAYER_COLOR_AQUA)       return [6.27, 38.43, 27.84]
-  else if (GetPlayerColor(whichPlayer) == PLAYER_COLOR_BROWN)      return [30.98, 16.86, 1.96]
-  else if (GetPlayerColor(whichPlayer) == PLAYER_COLOR_MAROON)     return [61.18, 0.00, 0.00]
-  else if (GetPlayerColor(whichPlayer) == PLAYER_COLOR_NAVY)       return [0.00, 0.00, 76.47]
-  else if (GetPlayerColor(whichPlayer) == PLAYER_COLOR_TURQUOISE)  return [0.00, 92.16, 100.00]
-  else if (GetPlayerColor(whichPlayer) == PLAYER_COLOR_VIOLET)     return [74.12, 0.00, 100.00]
-  else if (GetPlayerColor(whichPlayer) == PLAYER_COLOR_WHEAT)      return [92.55, 80.78, 52.94]
-  else if (GetPlayerColor(whichPlayer) == PLAYER_COLOR_PEACH)      return [96.86, 64.71, 54.51]
-  else if (GetPlayerColor(whichPlayer) == PLAYER_COLOR_MINT)       return [74.90, 100.00, 50.59]
-  else if (GetPlayerColor(whichPlayer) == PLAYER_COLOR_LAVENDER)   return [85.88, 72.16, 92.16]
-  else if (GetPlayerColor(whichPlayer) == PLAYER_COLOR_COAL)       return [30.98, 31.37, 33.33]
-  else if (GetPlayerColor(whichPlayer) == PLAYER_COLOR_SNOW)       return [92.55, 94.12, 100.00]
-  else if (GetPlayerColor(whichPlayer) == PLAYER_COLOR_EMERALD)    return [0.00, 47.06, 11.76]
-  else if (GetPlayerColor(whichPlayer) == PLAYER_COLOR_PEANUT)     return [64.71, 43.53, 20.39]
-  else                                                             return [18.04, 17.65, 18.04]
+function getPlayerRGBCode(whichPlayer: MapPlayer) {
+  return playerColors[GetHandleId(whichPlayer.color)];
 }
 
 function showExclamationOverDyingUnit(type: string) {
-  let col: number[] = getPlayerRGBCode(GetOwningPlayer(GetKillingUnitBJ()))
-  let tag: texttag  = CreateTextTagUnitBJ("!", GetDyingUnit(), -50.00, 12, col[0], col[1], col[2], 0)
-  SetTextTagPermanentBJ(tag, false)
-  SetTextTagLifespanBJ(tag, 2.00)
-  SetTextTagFadepointBJ(tag, 1.50)
+  const u = Unit.fromEvent();
+  const p = Unit.fromHandle(GetKillingUnit());
+  const lp = MapPlayer.fromLocal();
+  const color = getPlayerRGBCode(p.owner)
+  const tt = new TextTag();
+  tt.setText("!", 12, true);
+  tt.setPosUnit(u, -50.00);
+  tt.setColor(color.red, color.green, color.blue, 0);
+  tt.setPermanent(false);
+  tt.setLifespan(2.00);
+  tt.setFadepoint(1.50);
 
   if (type == "UNIT_DENY") {
     // Only show if the player actually has vision of the dying unit (or if player is observer);
     // that way players won't see denies in fog of war
-    SetTextTagVisibility(tag, (IsUnitInvisible(GetDyingUnit(), GetLocalPlayer()) == false &&
-                               IsUnitFogged   (GetDyingUnit(), GetLocalPlayer()) == false &&
-                               IsUnitMasked   (GetDyingUnit(), GetLocalPlayer()) == false) ||
-                              GetPlayerState(GetLocalPlayer(), PLAYER_STATE_OBSERVER) == 1)
+    const flag = (!u.isVisible(lp) && !u.isFogged(lp) && u.isMasked(lp) || lp.isObserver())
+    tt.setVisible(flag);
   }
   else if (type == "CREEP_LAST_HIT") {
     // Only show if the player is an observer
-    SetTextTagVisibility(tag, GetPlayerState(GetLocalPlayer(), PLAYER_STATE_OBSERVER) == 1)
+    tt.setVisible(lp.isObserver());
   }
 }
 
 function enableUnitDenyTrigger() {
-  // Returns TRUE if the unit that was killed belongs to the same player who killed it
-  let checkDyingUnitBelongsToKiller = () => { return GetOwningPlayer(GetDyingUnit()) == GetOwningPlayer(GetKillingUnitBJ()) }
-
-  let unitDenyTrigger: trigger = CreateTrigger()
-  TriggerRegisterAnyUnitEventBJ(unitDenyTrigger, EVENT_PLAYER_UNIT_DEATH)
-  TriggerAddCondition(unitDenyTrigger, Condition(checkDyingUnitBelongsToKiller))
-  TriggerAddAction(unitDenyTrigger, () => showExclamationOverDyingUnit("UNIT_DENY"))
+  const t = new Trigger()
+  t.registerAnyUnitEvent(EVENT_PLAYER_UNIT_DEATH);
+  t.addCondition(() => Unit.fromEvent().owner === Unit.fromHandle(GetKillingUnit()).owner); // Returns TRUE if the unit that was killed belongs to the same player who killed it
+  t.addAction(() => showExclamationOverDyingUnit("UNIT_DENY"));
 }
 
 function enableCreepLastHitTrigger() {
-  let checkDyingUnitIsCreepAndLocalPlayerIsObserverAndEnemyIsNearby = () => {
+  const checkDyingUnitIsCreepAndLocalPlayerIsObserverAndEnemyIsNearby = () => {
+    const u = Unit.fromEvent();
+    const killer = Unit.fromHandle(GetKillingUnit());
+
     // Returns FALSE if dying unit is NOT a creep
-    if (GetOwningPlayer(GetDyingUnit()) != Player(PLAYER_NEUTRAL_AGGRESSIVE))
-      return false
+    if (u.owner != Players[PLAYER_NEUTRAL_AGGRESSIVE]) {
+      return false;
+    }
 
     // Returns FALSE when no enemy units are nearby (e.g. range 800 = coil range)
-    let atLeast1EnemyNearby: boolean = false
-    ForGroupBJ(GetUnitsInRangeOfLocAll(1000.00, GetUnitLoc(GetDyingUnit())), () => {
-      if (IsUnitEnemy(GetEnumUnit(), GetOwningPlayer(GetKillingUnitBJ())) == true && GetOwningPlayer(GetEnumUnit()) != Player(PLAYER_NEUTRAL_AGGRESSIVE))
-        atLeast1EnemyNearby = true
-    })
+    const g = new Group();
+    g.enumUnitsInRange(u.x, u.y, 1000, () => u.isEnemy(killer.owner) && Unit.fromEnum().owner !== Players[PLAYER_NEUTRAL_AGGRESSIVE]);
+    const atLeast1EnemyNearby = g.size > 0;
+    g.destroy();
     return atLeast1EnemyNearby
   }
 
-  let creepLastHitTriger: trigger = CreateTrigger()
-  TriggerRegisterAnyUnitEventBJ(creepLastHitTriger, EVENT_PLAYER_UNIT_DEATH)
-  TriggerAddCondition(creepLastHitTriger, Condition(checkDyingUnitIsCreepAndLocalPlayerIsObserverAndEnemyIsNearby))
-  TriggerAddAction(creepLastHitTriger, () => showExclamationOverDyingUnit("CREEP_LAST_HIT"))
+  const t = new Trigger();
+  t.registerAnyUnitEvent(EVENT_PLAYER_UNIT_DEATH);
+  t.addCondition(() => checkDyingUnitIsCreepAndLocalPlayerIsObserverAndEnemyIsNearby());
+  t.addAction(() => showExclamationOverDyingUnit("CREEP_LAST_HIT"));
 }
 
 function enableItemSoldTrigger() {
   let stackCounter: number = 0
-  let itemSoldTrigger: trigger = CreateTrigger()
-  TriggerRegisterAnyUnitEventBJ(itemSoldTrigger, EVENT_PLAYER_UNIT_PAWN_ITEM)
-  
-  TriggerAddAction(itemSoldTrigger, () => {
-    stackCounter = ModuloReal(stackCounter + 1, 3.00)
-    let col: number[] = getPlayerRGBCode(GetOwningPlayer(GetSellingUnit()))
-    let tag: texttag = CreateTextTagUnitBJ("Sold \"" + GetItemName(GetSoldItem()) + "\"", GetSellingUnit(), (-50.00 + (-50.00 * stackCounter)), 10, col[0], col[1], col[2], 0)
-    SetTextTagPermanentBJ(tag, false)
-    SetTextTagVelocityBJ(tag, 30, (50.00 + (-50.00 * stackCounter)))
-    SetTextTagLifespanBJ(tag, 2.00)
-    SetTextTagFadepointBJ(tag, 1.50)
+
+  const t = new Trigger();
+  t.registerAnyUnitEvent(EVENT_PLAYER_UNIT_PAWN_ITEM);
+  t.addAction(() => {
+    const u = Unit.fromHandle(GetSellingUnit());
+    const itm = Item.fromHandle(GetSoldItem());
+
+    stackCounter = ModuloReal(stackCounter + 1, 3.00);
+    const color = getPlayerRGBCode(u.owner);
+    const tt = new TextTag();
+    tt.setText(`Sold "${itm.name}"`, 10, true);
+    tt.setPosUnit(u, (-50.00 + (-50.00 * stackCounter)));
+    tt.setColor(color.red, color.green, color.blue, 0);
+    tt.setPermanent(false);
+    tt.setVelocityAngle(30, (50.00 + (-50.00 * stackCounter)));
+    tt.setLifespan(2.00);
+    tt.setFadepoint(1.50);
 
     // Only show if the local player is an observer
-    SetTextTagVisibility(tag, GetPlayerState(GetLocalPlayer(), PLAYER_STATE_OBSERVER) == 1)
+    tt.setVisible(MapPlayer.fromLocal().isObserver());
   })
 }
+
+addScriptHook(W3TS_HOOK.MAIN_AFTER, init);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "outDir": ".",
     "baseUrl": "./src",
     "allowJs": true,
     "target": "es6",


### PR DESCRIPTION
Added for both Players & Observers:
- Showing `!` for denying a unit (in colour of player who denied their own unit)
![image](https://user-images.githubusercontent.com/32247590/103769257-e0c0c180-501b-11eb-8d67-f301534cf0ec.png)


Added for **observers only**:
- Showing `!` for last hit on creep (in colour of player who got the creep); only triggers if enemy units are nearby _(so observers don't get spammed when players just creep by themselves)_
![image](https://user-images.githubusercontent.com/32247590/103770719-5e85cc80-501e-11eb-8c53-07941cbe1802.png)
- Showing e.g. `Sold "Claws of Attack +5"` when item is sold (in colour of player who sold the item)
![image](https://user-images.githubusercontent.com/32247590/103769670-9ee44b00-501c-11eb-8f25-fac97a07d268.png)
