### PR TITLE
More fixes for -gg and 1.33 quest crash

### DIFF
--- a/src/observer_features/listOfCreepKills.ts
+++ b/src/observer_features/listOfCreepKills.ts
@@ -5,7 +5,7 @@ import { Unit, Trigger, MapPlayer, Quest, getElapsedTime } from "w3ts/index";
 export function enableListOfCreepKills() {
   const q = new Quest();
   q.setTitle("Creep Kills")
-  q.setDescription("")
+  q.setDescription("No Kills yet.")
   q.setIcon("ReplaceableTextures\\CommandButtons\\BTNTomeBrown.blp")
   
   const getFormattedElapsedTime = () => {

--- a/src/player_features/draw.ts
+++ b/src/player_features/draw.ts
@@ -61,7 +61,7 @@ export function enableDraw() {
             drawPlayers.splice(drawPlayers.indexOf(triggerPlayer.name), 1);
         }
 
-        if (drawPlayers.length == requiredDrawPlayers) {
+        if (drawPlayers.length != 0 && drawPlayers.length == requiredDrawPlayers) {
             for (let i = 0; i < bj_MAX_PLAYERS; i++) {
                 RemovePlayerPreserveUnitsBJ(Player(i), PLAYER_GAME_RESULT_NEUTRAL, false);
             }

--- a/src/player_features/forfeit.ts
+++ b/src/player_features/forfeit.ts
@@ -29,11 +29,11 @@ export function enableForfeit() {
             
             if (forfeitPlayers[team].length == 1) {
                 if (GetPlayerTeam(GetLocalPlayer()) == team) {
-                    print(`|cff00ff00[W3C]:|r|cffFF4500 ${triggerPlayer.name}|r is proposing to forfeit this game. \nType|cffffff00 -gg|r to vote. ${remainingPlayers} player(s) remaining.`);
+                    print(`|cff00ff00[W3C]:|r|cffFF4500 ${triggerPlayer.name}|r is proposing to surrender this game. \nType|cffffff00 -gg|r to vote. ${remainingPlayers} player(s) remaining.`);
                 }
                 TimerStart(expiryTimers[team], expiryTime, false, null);
             } else if (GetPlayerTeam(GetLocalPlayer()) == team && forfeitPlayers[team].length < requiredForfeitPlayers[team]) {
-                print(`|cff00ff00[W3C]:|r|cffFF4500 ${triggerPlayer.name}|r voted to forfeit this game. ${remainingPlayers} player(s) remaining.`);
+                print(`|cff00ff00[W3C]:|r|cffFF4500 ${triggerPlayer.name}|r voted to surrender this game. ${remainingPlayers} player(s) remaining.`);
             }
         }
 
@@ -57,7 +57,7 @@ export function enableForfeit() {
             forfeitPlayers[team].splice(forfeitPlayers[team].indexOf(triggerPlayer.name), 1);
         }
 
-        if (forfeitPlayers[team].length == requiredForfeitPlayers[team]) {
+        if (forfeitPlayers[team].length != 0 && forfeitPlayers[team].length == requiredForfeitPlayers[team]) {
             for (let i = 0; i < bj_MAX_PLAYERS; i++) {
                 if (GetPlayerTeam(Player(i)) == team) {
                     RemovePlayerPreserveUnitsBJ(Player(i), PLAYER_GAME_RESULT_DEFEAT, false);
@@ -71,7 +71,7 @@ export function enableForfeit() {
     TriggerAddAction(expireForfeitTrigger[index], () => {
         forfeitPlayers[index].splice(0, forfeitPlayers[index].length);
         if (GetPlayerTeam(GetLocalPlayer()) == index) {
-            print(`|cff00ff00[W3C]|r: Forfeiting expired.`)
+            print(`|cff00ff00[W3C]|r: Surrender expired.`)
         }
     });
     })(i);

--- a/src/player_features/forfeit.ts
+++ b/src/player_features/forfeit.ts
@@ -40,9 +40,10 @@ export function enableForfeit() {
         if (forfeitPlayers[team].length == requiredForfeitPlayers[team]) {
             for (let i = 0; i < bj_MAX_PLAYERS; i++) {
                 if (GetPlayerTeam(Player(i)) == team) {
-                    RemovePlayerPreserveUnitsBJ(Player(i), PLAYER_GAME_RESULT_DEFEAT, false);
+                    MeleeDoDefeat(Player(i));
                 }
             }
+            MeleeCheckForLosersAndVictors();
         }
     });
 	
@@ -60,9 +61,10 @@ export function enableForfeit() {
         if (forfeitPlayers[team].length != 0 && forfeitPlayers[team].length == requiredForfeitPlayers[team]) {
             for (let i = 0; i < bj_MAX_PLAYERS; i++) {
                 if (GetPlayerTeam(Player(i)) == team) {
-                    RemovePlayerPreserveUnitsBJ(Player(i), PLAYER_GAME_RESULT_DEFEAT, false);
+                    MeleeDoDefeat(Player(i));
                 }
             }
+            MeleeCheckForLosersAndVictors();
         }
     });
 

--- a/src/showCommands.ts
+++ b/src/showCommands.ts
@@ -10,7 +10,9 @@ export function enableShowCommandsTrigger() {
         DisplayTimedTextToPlayer(GetTriggerPlayer(), 0, 0, 10, `\n|cff00ff00[W3C Commands]:|r\n` +
             `  |cffffff00•|r Type|cffffff00 !flo|r for FLO details. (FLO games only)\n` +
             `  |cffffff00•|r Type|cffffff00 -draw|r to cancel game. Expires after 2 min. Disabled in tournaments.\n` +
-            `  |cffffff00•|r Type|cffffff00 -gg|r to vote to forfeit the game. (4v4 games only)\n` +
+            `  |cffffff00•|r Type|cffffff00 -gg|r to surrender (4v4 only). Can be initiated every 3 min.\n` +
+            `     Completing the vote grants immunity to being reported for leaving early.\n` +
+            `     Game counts as a loss. 3/4 votes required.\n` +
             `  |cffffff00•|r Type|cffffff00 -zoom <VALUE>|r to set zoom level. (1650 - 3000)\n` +
             `  |cffffff00•|r Type|cffffff00 -z|r or press|cffffff00 F5|r to reset zoom to preferred value.\n` +
             `  |cffffff00•|r Type|cffffff00 -deny|r to show/hide|cffffff00 !|r when a player's unit is denied.\n` +


### PR DESCRIPTION
Empty quest descriptions crash 1.33, so a default text has been added
If 3 people leave without anyone doing -gg, old code will have still defeated the last player, so a check was added for when there were no players voting to forfeit
Melee defeat functions are used so the winning team is correctly assigned as soon as -gg finishes
And the command descriptions were changed to make them a bit easier to understand