### PR TITLE
Hide exit button

### DIFF
--- a/src/player_features/hideGameButtons.ts
+++ b/src/player_features/hideGameButtons.ts
@@ -5,7 +5,5 @@ export function hideGameButtons() {
         BlzFrameSetVisible(BlzGetFrameByName("EscMenuSaveLoadContainer", 0), false);
         BlzFrameSetEnable(BlzGetFrameByName("SaveGameFileEditBox" , 0), false);
         BlzFrameSetVisible(BlzGetFrameByName("ExitButton" , 0), false);
-        BlzFrameSetEnable(BlzGetFrameByName("ConfirmQuitQuitButton" , 0), false);
-        BlzFrameSetText(BlzGetFrameByName("ConfirmQuitMessageText", 0), "\nPlease use Quit Mission instead\n\nF10 + E + Q")
     });
 }

--- a/src/player_features/hideGameButtons.ts
+++ b/src/player_features/hideGameButtons.ts
@@ -4,5 +4,8 @@ export function hideGameButtons() {
     TriggerAddAction(hideGameButtons, () => {
         BlzFrameSetVisible(BlzGetFrameByName("EscMenuSaveLoadContainer", 0), false);
         BlzFrameSetEnable(BlzGetFrameByName("SaveGameFileEditBox" , 0), false);
+        BlzFrameSetVisible(BlzGetFrameByName("ExitButton" , 0), false);
+        BlzFrameSetEnable(BlzGetFrameByName("ConfirmQuitQuitButton" , 0), false);
+        BlzFrameSetText(BlzGetFrameByName("ConfirmQuitMessageText", 0), "\nPlease use Quit Mission instead\n\nF10 + E + Q")
     });
 }


### PR DESCRIPTION
When users exit the game instead of pressing quit mission, their game is not recorded in w3champions. Everyday there is some confusion and sadness about this.

**After this change**

In F10 > E menu, exit game button is gone

![image](https://github.com/user-attachments/assets/82d3a91f-11e7-478e-9fe4-d023ea793d09)
