### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,30 +9,30 @@
     "test": "ts-node --transpile-only scripts/test.ts",
     "build": "ts-node --transpile-only scripts/build.ts",
     "dev": "npm-watch",
-    "postinstall": "tsc --outDir null -p node_modules/mdx-m3-viewer/tsconfig.json",
     "build:defs": "ts-node scripts/dev"
   },
   "dependencies": {
-    "w3ts": "^2.2.1"
+    "w3gjs": "^3.0.0",
+    "w3ts": "^3.0.2"
   },
   "devDependencies": {
-    "@types/fs-extra": "8.1.1",
-    "@types/node": "12.19.12",
-    "@types/pako": "1.0.1",
-    "fs-extra": "8.1.0",
-    "lua-types": "2.8.0",
+    "@types/fs-extra": "11.0.4",
+    "@types/node": "22.15.17",
+    "@types/pako": "2.0.3",
+    "fs-extra": "11.3.0",
+    "lua-types": "2.13.1",
     "luamin": "1.0.4",
-    "mdx-m3-viewer": "5.2.3",
-    "npm-watch": "0.6.0",
-    "ts-node": "8.10.2",
-    "tsconfig-paths": "3.9.0",
-    "tsutils": "3.19.0",
-    "typescript": "4.1.3",
-    "typescript-to-lua": "0.36.1",
-    "war3-transformer": "2.0.0",
-    "war3-types": "1.0.4",
+    "mdx-m3-viewer": "5.12.0",
+    "npm-watch": "0.13.0",
+    "ts-node": "10.9.2",
+    "tsconfig-paths": "4.2.0",
+    "tsutils": "3.21.0",
+    "typescript": "5.8.2",
+    "typescript-to-lua": "^1.31.0",
+    "war3-objectdata-th": "^0.2.10",
+    "war3-transformer": "3.0.9",
     "war3tstlhelper": "1.0.1",
-    "winston": "3.3.3"
+    "winston": "3.17.0"
   },
   "watch": {
     "build:defs": {

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -1,6 +1,6 @@
 import * as fs from "fs-extra";
 import * as path from "path";
-import War3Map from "mdx-m3-viewer/src/parsers/w3x/map";
+import War3Map from "mdx-m3-viewer/dist/cjs/parsers/w3x/map";
 import { compileMap, getFilesInDirectory, loadJsonFile, logger, toArrayBuffer, IProjectConfig } from "./utils";
 
 function main() {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,19 +1,19 @@
-import { enableDraw } from "player_features/draw";
-import { enableBuildingCancelTrigger } from "observer_features/buildingCancel";
-import { enableItemSoldBoughtTrigger } from "observer_features/itemSoldBought";
-import { enableListOfCreepKills } from "observer_features/listOfCreepKills";
-import { enableShowCommandsTrigger } from "showCommands";
-import { enableUnitDenyTrigger } from "player_features/unitDeny";
+import { enableDraw } from "./player_features/draw";
+import { enableBuildingCancelTrigger } from "./observer_features/buildingCancel";
+import { enableItemSoldBoughtTrigger } from "./observer_features/itemSoldBought";
+import { enableListOfCreepKills } from "./observer_features/listOfCreepKills";
+import { enableShowCommandsTrigger } from "./showCommands";
+import { enableUnitDenyTrigger } from "./player_features/unitDeny";
 import { addScriptHook, W3TS_HOOK } from "w3ts/hooks";
-import { enableWorkerCount } from "player_features/workercount";
-import { enableCameraZoom } from "player_features/zoom";
-import { initMatchEndTimers } from "tournamentMatch";
-import { getGameMode, MapGameMode } from "utils";
-import { anonymizePlayerNames } from "player_features/anonymizeNames";
-import { enableForfeit } from "player_features/forfeit";
-import { enableCustomMinimapIcons } from "player_features/customMinimapIcons";
-import { hideGameButtons } from "player_features/hideGameButtons";
-import { enableClock } from "player_features/clock";
+import { enableWorkerCount } from "./player_features/workercount";
+import { enableCameraZoom } from "./player_features/zoom";
+import { initMatchEndTimers } from "./tournamentMatch";
+import { getGameMode, MapGameMode } from "./utils";
+import { anonymizePlayerNames } from "./player_features/anonymizeNames";
+import { enableForfeit } from "./player_features/forfeit";
+import { enableCustomMinimapIcons } from "./player_features/customMinimapIcons";
+import { hideGameButtons } from "./player_features/hideGameButtons";
+import { enableClock } from "./player_features/clock";
 
 function init() {
   enableShowCommandsTrigger();

--- a/src/observer_features/buildingCancel.ts
+++ b/src/observer_features/buildingCancel.ts
@@ -1,4 +1,4 @@
-import { showMessageOverUnit } from "utils";
+import { showMessageOverUnit } from "../utils";
 import { Unit, MapPlayer, Trigger } from "w3ts/index";
 import { Players } from "w3ts/globals/index";
 

--- a/src/observer_features/itemSoldBought.ts
+++ b/src/observer_features/itemSoldBought.ts
@@ -1,4 +1,4 @@
-import { getPlayerRGBCode } from "utils";
+import { getPlayerRGBCode } from "../utils";
 import { Trigger, Unit, Item, TextTag, MapPlayer } from "w3ts/index";
 
 export function enableItemSoldBoughtTrigger() {

--- a/src/observer_features/listOfCreepKills.ts
+++ b/src/observer_features/listOfCreepKills.ts
@@ -1,4 +1,4 @@
-import { getPlayerNameWithoutNumber, getPlayerHexCode } from "utils";
+import { getPlayerNameWithoutNumber, getPlayerHexCode } from "../utils";
 import { Players } from "w3ts/globals/index";
 import { Unit, Trigger, MapPlayer, Quest, getElapsedTime } from "w3ts/index";
 

--- a/src/player_features/unitDeny.ts
+++ b/src/player_features/unitDeny.ts
@@ -1,4 +1,4 @@
-import { showMessageOverUnit } from "utils";
+import { showMessageOverUnit } from "../utils";
 import { Unit, MapPlayer, Trigger, File } from "w3ts/index";
 import { Players } from "w3ts/globals/index";
 

--- a/src/showCommands.ts
+++ b/src/showCommands.ts
@@ -1,4 +1,4 @@
-import { getGameMode, MapGameMode } from "utils";
+import { getGameMode, MapGameMode } from "./utils";
 
 export function enableShowCommandsTrigger() {
     let showCommandsTrigger = CreateTrigger();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "lib": [
       "es6"
     ],
-    "moduleResolution": "classic",
+    "moduleResolution": "node",
     "paths": {
       "*": [
         "../node_modules/*/src/index",
@@ -14,6 +14,9 @@
         "../node_modules/*/index",
         "../node_modules/*/dist/index",
         "../node_modules/*"
+      ],
+      "@objectdata/*": [
+        "./node_modules/war3-objectdata-th/dist/cjs/generated/constants/*"
       ]
     },
     "plugins": [
@@ -22,6 +25,7 @@
       }
     ],
     "types": [
+      "@typescript-to-lua/language-extensions",
       "lua-types/core/coroutine",
       "lua-types/core/global",
       "lua-types/core/math",
@@ -31,13 +35,9 @@
       "lua-types/core/table",
       "lua-types/core/os",
       "lua-types/special/5.3",
-      "war3-types/core/compat",
-      "war3-types/core/common",
-      "war3-types/core/blizzard",
-      "war3-types/core/commonai",
-      "war3-types/core/polyfill",
-      "war3-types/special/w3ts",
-      "mdx-m3-viewer/src/types"
+      "war3-types-strict/1.33.0",
+      "war3-transformer/types",
+      "war3-objectdata-th/dist/cjs/objectdata"
     ]
   },
   "include": [
@@ -50,6 +50,10 @@
     "luaLibImport": "require",
     "noImplicitSelf": true,
     "luaBundle": "dist/tstl_output.lua",
-    "luaBundleEntry": "./src/main.ts"
+    "luaBundleEntry": "./src/main.ts",
+    "noResolvePaths": [
+      "typescript",
+      "typescript-to-lua"
+    ]
   }
 }


### PR DESCRIPTION
Mostly needed for typescript-to-lua version update so that it can include lua files in the bundled output. The current version we use doesn't do it.

Some changes to wc3 types based on the latest version of the https://github.com/cipherxof/wc3-ts-template

Update to module resolution is due to dependencies requiring node resolution, which requires us changing some imports to use node resolution.