### PR TITLE
disable Exit button

### DIFF
--- a/src/player_features/hideGameButtons.ts
+++ b/src/player_features/hideGameButtons.ts
@@ -5,5 +5,7 @@ export function hideGameButtons() {
         BlzFrameSetVisible(BlzGetFrameByName("EscMenuSaveLoadContainer", 0), false);
         BlzFrameSetEnable(BlzGetFrameByName("SaveGameFileEditBox" , 0), false);
         BlzFrameSetVisible(BlzGetFrameByName("ExitButton" , 0), false);
+        BlzFrameSetEnable(BlzGetFrameByName("ConfirmQuitQuitButton" , 0), false);
+        BlzFrameSetText(BlzGetFrameByName("ConfirmQuitMessageText", 0), "Please use Quit Mission instead.");
     });
 }


### PR DESCRIPTION
Before
![defaultdialog](https://github.com/user-attachments/assets/a41a872d-d37a-4593-a59f-a31fa740fc5a)
After
![disable](https://github.com/user-attachments/assets/cabe7c1c-2ac4-4938-95e7-afe9d5e3a041)

Note: Removing the "Exit Game" button has already been merged https://github.com/w3champions/map-updater-scripts/pull/32

This PR will help with people getting to the "Confirm Exit" dialog by pressing alt + f4 