### PR TITLE
Enable Exit Button for Observers

### DIFF
--- a/src/player_features/hideGameButtons.ts
+++ b/src/player_features/hideGameButtons.ts
@@ -2,10 +2,12 @@ export function hideGameButtons() {
     let hideGameButtons = CreateTrigger();
     TriggerRegisterTimerEventSingle(hideGameButtons, 0.00);
     TriggerAddAction(hideGameButtons, () => {
-        BlzFrameSetVisible(BlzGetFrameByName("EscMenuSaveLoadContainer", 0), false);
-        BlzFrameSetEnable(BlzGetFrameByName("SaveGameFileEditBox" , 0), false);
-        BlzFrameSetVisible(BlzGetFrameByName("ExitButton" , 0), false);
-        BlzFrameSetEnable(BlzGetFrameByName("ConfirmQuitQuitButton" , 0), false);
-        BlzFrameSetText(BlzGetFrameByName("ConfirmQuitMessageText", 0), "Please use Quit Mission instead.");
+        if (!IsPlayerObserver(GetLocalPlayer())) {    
+            BlzFrameSetVisible(BlzGetFrameByName("EscMenuSaveLoadContainer", 0), false);
+            BlzFrameSetEnable(BlzGetFrameByName("SaveGameFileEditBox" , 0), false);
+            BlzFrameSetVisible(BlzGetFrameByName("ExitButton" , 0), false);
+            BlzFrameSetEnable(BlzGetFrameByName("ConfirmQuitQuitButton" , 0), false);
+            BlzFrameSetText(BlzGetFrameByName("ConfirmQuitMessageText", 0), "Please use Quit Mission instead.");
+        }
     });
 }


### PR DESCRIPTION
There is no reason why the Exit Button should be disabled for the observers.

Based on my PR https://github.com/Warcraft-3-Risk/wc3-risk-system/pull/199 that was inspired by this one https://github.com/w3champions/map-updater-scripts/pull/37.