### PR TITLE
Resolve desync issue for enabling Exit Button for Observers

### DIFF
--- a/src/player_features/hideGameButtons.ts
+++ b/src/player_features/hideGameButtons.ts
@@ -2,12 +2,19 @@ export function hideGameButtons() {
     let hideGameButtons = CreateTrigger();
     TriggerRegisterTimerEventSingle(hideGameButtons, 0.00);
     TriggerAddAction(hideGameButtons, () => {
-        if (!IsPlayerObserver(GetLocalPlayer())) {    
-            BlzFrameSetVisible(BlzGetFrameByName("EscMenuSaveLoadContainer", 0), false);
-            BlzFrameSetEnable(BlzGetFrameByName("SaveGameFileEditBox" , 0), false);
-            BlzFrameSetVisible(BlzGetFrameByName("ExitButton" , 0), false);
-            BlzFrameSetEnable(BlzGetFrameByName("ConfirmQuitQuitButton" , 0), false);
-            BlzFrameSetText(BlzGetFrameByName("ConfirmQuitMessageText", 0), "Please use Quit Mission instead.");
-        }
+        // Get all BlzGetFrameByName handles outside of local scope to prevent async issues
+		const escMenuSaveLoadContainer: framehandle = BlzGetFrameByName('EscMenuSaveLoadContainer', 0);
+		const saveGameFileEditBox: framehandle = BlzGetFrameByName('SaveGameFileEditBox', 0);
+		const exitButton: framehandle = BlzGetFrameByName('ExitButton', 0);
+		const confirmQuitQuitButton: framehandle = BlzGetFrameByName('ConfirmQuitQuitButton', 0);
+		const confirmQuitMessageText: framehandle = BlzGetFrameByName('ConfirmQuitMessageText', 0);
+
+		if (!IsPlayerObserver(GetLocalPlayer())) {
+			BlzFrameSetVisible(escMenuSaveLoadContainer, false);
+			BlzFrameSetEnable(saveGameFileEditBox, false);
+			BlzFrameSetVisible(exitButton, false);
+			BlzFrameSetEnable(confirmQuitQuitButton, false);
+			BlzFrameSetText(confirmQuitMessageText, 'Please use Quit Mission instead.');
+		}
     });
 }

--- a/src/player_features/hideGameButtons.ts
+++ b/src/player_features/hideGameButtons.ts
@@ -3,18 +3,18 @@ export function hideGameButtons() {
     TriggerRegisterTimerEventSingle(hideGameButtons, 0.00);
     TriggerAddAction(hideGameButtons, () => {
         // Get all BlzGetFrameByName handles outside of local scope to prevent async issues
-		const escMenuSaveLoadContainer: framehandle = BlzGetFrameByName('EscMenuSaveLoadContainer', 0);
-		const saveGameFileEditBox: framehandle = BlzGetFrameByName('SaveGameFileEditBox', 0);
-		const exitButton: framehandle = BlzGetFrameByName('ExitButton', 0);
-		const confirmQuitQuitButton: framehandle = BlzGetFrameByName('ConfirmQuitQuitButton', 0);
-		const confirmQuitMessageText: framehandle = BlzGetFrameByName('ConfirmQuitMessageText', 0);
-
-		if (!IsPlayerObserver(GetLocalPlayer())) {
-			BlzFrameSetVisible(escMenuSaveLoadContainer, false);
-			BlzFrameSetEnable(saveGameFileEditBox, false);
-			BlzFrameSetVisible(exitButton, false);
-			BlzFrameSetEnable(confirmQuitQuitButton, false);
-			BlzFrameSetText(confirmQuitMessageText, 'Please use Quit Mission instead.');
-		}
+	const escMenuSaveLoadContainer: framehandle = BlzGetFrameByName('EscMenuSaveLoadContainer', 0);
+	const saveGameFileEditBox: framehandle = BlzGetFrameByName('SaveGameFileEditBox', 0);
+	const exitButton: framehandle = BlzGetFrameByName('ExitButton', 0);
+	const confirmQuitQuitButton: framehandle = BlzGetFrameByName('ConfirmQuitQuitButton', 0);
+	const confirmQuitMessageText: framehandle = BlzGetFrameByName('ConfirmQuitMessageText', 0);
+	
+	if (!IsPlayerObserver(GetLocalPlayer())) {
+		BlzFrameSetVisible(escMenuSaveLoadContainer, false);
+		BlzFrameSetEnable(saveGameFileEditBox, false);
+		BlzFrameSetVisible(exitButton, false);
+		BlzFrameSetEnable(confirmQuitQuitButton, false);
+		BlzFrameSetText(confirmQuitMessageText, 'Please use Quit Mission instead.');
+	}
     });
 }


### PR DESCRIPTION
Resolving desync issue caused by this PR

https://github.com/w3champions/map-updater-scripts/pull/40

Invoking BlzGetFrameByName creates a handle that is expected to be synched across clients. Moving this outside of the scope fixes this issue.