### PR TITLE
Add start game countdown

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -17,6 +17,7 @@ import { hideGameButtons } from "./player_features/hideGameButtons";
 import { enableClock } from "./player_features/clock";
 import { enableCreepLootIndicator } from "./player_features/loot-indicator/loot-indicator";
 import { detectGameStatusAndCache } from "./detectGameStatus";
+import {enableStartGameCountdown} from "./startGameCountdown";
 
 function init() {
   detectGameStatusAndCache();
@@ -49,6 +50,7 @@ function init() {
   }
 
   hideGameButtons();
+  enableStartGameCountdown();
 }
 
 

--- a/src/player_features/clock.ts
+++ b/src/player_features/clock.ts
@@ -1,4 +1,4 @@
-import { File, MapPlayer, Trigger } from "w3ts/index";
+import {File, MapPlayer, Trigger} from "w3ts/index";
 
 function Sec2Timer(i: number): string {
     let timeString = "Time: "
@@ -20,6 +20,19 @@ function Sec2Timer(i: number): string {
 
 let GameTimeSec: number = 0
 let isClockEnabled: boolean = true
+let clockTimer: timer = CreateTimer()
+
+function startClockTimer() {
+    TimerStart(clockTimer, 1, true, () => {
+        let timerTextFrame = BlzGetFrameByName("GameTime", 0)
+        GameTimeSec = GameTimeSec + 1
+        // Prevents the timer from going beyond 99:59
+        if (GameTimeSec >= 60000) // 1000 minutes in seconds
+            GameTimeSec = 59999 // Cap at 999:59
+
+        BlzFrameSetText(timerTextFrame, Sec2Timer(GameTimeSec))
+    });
+}
 
 export function enableClock() {
     let FH = BlzCreateFrameByType("TEXT", "GameTime", 
@@ -45,17 +58,7 @@ export function enableClock() {
         TriggerRegisterPlayerChatEvent(toggleClock, Player(i), "-clock", true);
     }
 
-
-
-    TimerStart(CreateTimer(), 1, true, function() {
-        let timerTextFrame = BlzGetFrameByName("GameTime", 0)
-        GameTimeSec = GameTimeSec + 1
-        // Prevents the timer from going beyond 99:59
-        if (GameTimeSec >= 60000) // 1000 minutes in seconds
-            GameTimeSec = 59999 // Cap at 999:59
-
-        BlzFrameSetText(timerTextFrame, Sec2Timer(GameTimeSec))
-    })
+    startClockTimer();
 
     TriggerAddAction(toggleClock, () => {
         let triggerPlayer = MapPlayer.fromEvent()
@@ -72,4 +75,15 @@ export function enableClock() {
 
         File.write("w3cClock.txt", isClockEnabled.toString());
     });
+}
+
+export function pauseClockW3C(pause: boolean) {
+    if (pause) {
+        PauseTimer(clockTimer);
+    } else {
+        //Can't use native `ResumeTimer()` because it has a bug and stops the timer after 2 seconds
+        //See https://lep.nrw/jassbot/doc/ResumeTimer
+        //Instead we're restarting the clock. Might affect TimerGetRemaining() function, but it is not used
+        startClockTimer();
+    }
 }

--- a/src/startGameCountdown.ts
+++ b/src/startGameCountdown.ts
@@ -1,8 +1,8 @@
-import {Timer} from "w3ts";
+import {color, Timer} from "w3ts";
 import {pauseClockW3C} from "./player_features/clock";
 import {Units} from "@objectdata/units";
 
-const COUNTDOWN_START = 5;
+const COUNTDOWN_START = 10;
 const COUNTDOWN_SOUND = CreateSound("Sound\\Interface\\BattleNetTick.wav", false, false, false, 10, 10, "",);
 
 export function enableStartGameCountdown() {
@@ -41,6 +41,7 @@ function recreateNeutralStockBuildings() {
         x: number;
         y: number;
         facing: number;
+        color: number;
     }
 
     function isNeutralStockBuilding(unitTypeId: number): boolean {
@@ -64,6 +65,8 @@ function recreateNeutralStockBuildings() {
             || unitTypeId === FourCC(Units.MercenaryCampSunkenRuins)
             || unitTypeId === FourCC(Units.MercenaryCampUnderground)
             || unitTypeId === FourCC(Units.MercenaryCampVillage);
+        //FIXME: add missing building (dragon roosts, etc)
+        //Check for "Tech tree - Units Sold or Items Sold" Fields
     }
 
     const buildings: NeutralBuildingData[] = [];
@@ -79,11 +82,18 @@ function recreateNeutralStockBuildings() {
             return;
         }
 
+        //"Art - Team Color" property of an object.
+        // if -1 then inherit from the owner.
+        // >=0 player number to inherit color from. For example, 0 for Player 1 (Red)
+        //FIXME: this does not work, make a static table
+        const teamColorPlayer = BlzGetUnitIntegerField(unit, ConvertUnitIntegerField(FourCC('utco')))
+        print(teamColorPlayer)
         buildings.push({
             unitTypeId,
             x: GetUnitX(unit),
             y: GetUnitY(unit),
             facing: GetUnitFacing(unit),
+            color: teamColorPlayer,
         });
 
         RemoveUnit(unit);
@@ -92,6 +102,43 @@ function recreateNeutralStockBuildings() {
     DestroyGroup(group);
 
     for (const building of buildings) {
-        CreateUnit(Player(PLAYER_NEUTRAL_PASSIVE), building.unitTypeId, building.x, building.y, building.facing);
+        const unit = CreateUnit(Player(PLAYER_NEUTRAL_PASSIVE), building.unitTypeId, building.x, building.y, building.facing);
+        if(building.color >= 0 && building.color < bj_MAX_PLAYERS) {
+            // SetUnitColor(unit, GetPlayerColor(Player(building.color)));
+        }
     }
 }
+
+/** All Neutral Passive Buildings:
+ * ngol (Gold Mine)
+ * ngme (Goblin Merchant)
+ * nfoh (Fountain of Health)
+ * nmoo (Fountain of Mana)
+ * ngad (Goblin Laboratory)
+ * nwgt (Way Gate)
+ * ndrk (Black Dragon Roost)
+ * ndru (Blue Dragon Roost)
+ * ndrz (Bronze Dragon Roost)
+ * ndrg (Green Dragon Roost)
+ * ndro (Nether Dragon Roost)
+ * ndrr (Red Dragon Roost)
+ * nmer (Mercenary Camp (Lordaeron Summer))
+ * nmr2 (Mercenary Camp (Lordaeron Fall))
+ * nmr3 (Mercenary Camp (Lordaeron Winter))
+ * nmr4 (Mercenary Camp (Barrens))
+ * nmr5 (Mercenary Camp (Ashenvale))
+ * nmr6 (Mercenary Camp (Felwood))
+ * nmr7 (Mercenary Camp (Northrend))
+ * nmr8 (Mercenary Camp (Cityscape))
+ * nmr9 (Mercenary Camp (Dalaran))
+ * nmr0 (Mercenary Camp (Village))
+ * nmra (Mercenary Camp (Dungeon))
+ * nmrb (Mercenary Camp (Underground))
+ * ntav (Tavern)
+ * nmrk (Marketplace)
+ * nmrc (Mercenary Camp (Sunken Ruins))
+ * nmrd (Mercenary Camp (Icecrown Glacier))
+ * nshp (Goblin Shipyard)
+ * nmre (Mercenary Camp (Outland))
+ * nmrf (Mercenary Camp (Black Citadel))
+ */

--- a/src/startGameCountdown.ts
+++ b/src/startGameCountdown.ts
@@ -1,5 +1,6 @@
 import {Timer} from "w3ts";
 import {pauseClockW3C} from "./player_features/clock";
+import {Units} from "@objectdata/units";
 
 const COUNTDOWN_START = 5;
 const COUNTDOWN_SOUND = CreateSound("Sound\\Interface\\BattleNetTick.wav", false, false, false, 10, 10, "",);
@@ -17,8 +18,9 @@ export function enableStartGameCountdown() {
 
 function onCountdown(count: number) {
     if (count === 0) {
-        pauseGameW3C(false);
         ClearTextMessages();
+        recreateNeutralStockBuildings();
+        pauseGameW3C(false);
         return;
     }
 
@@ -30,4 +32,66 @@ function pauseGameW3C(pause: boolean) {
     PauseAllUnitsBJ(pause);
     SuspendTimeOfDay(pause);
     pauseClockW3C(pause);
+}
+
+// Recreating tavern/shop/merc resets initial stock cooldown delay for heroes/items/units in them
+function recreateNeutralStockBuildings() {
+    interface NeutralBuildingData {
+        unitTypeId: number;
+        x: number;
+        y: number;
+        facing: number;
+    }
+
+    function isNeutralStockBuilding(unitTypeId: number): boolean {
+        return unitTypeId === FourCC(Units.Tavern)
+            || unitTypeId === FourCC(Units.GoblinMerchant)
+            || unitTypeId === FourCC(Units.Marketplace)
+            || unitTypeId === FourCC(Units.GoblinLaboratory)
+            || unitTypeId === FourCC(Units.MercenaryCampAshenvale)
+            || unitTypeId === FourCC(Units.MercenaryCampBarrens)
+            || unitTypeId === FourCC(Units.MercenaryCampBlackCitadel)
+            || unitTypeId === FourCC(Units.MercenaryCampCityscape)
+            || unitTypeId === FourCC(Units.MercenaryCampDalaran)
+            || unitTypeId === FourCC(Units.MercenaryCampDungeon)
+            || unitTypeId === FourCC(Units.MercenaryCampFelwood)
+            || unitTypeId === FourCC(Units.MercenaryCampIcecrownGlacier)
+            || unitTypeId === FourCC(Units.MercenaryCampLordaeronFall)
+            || unitTypeId === FourCC(Units.MercenaryCampLordaeronSummer)
+            || unitTypeId === FourCC(Units.MercenaryCampLordaeronWinter)
+            || unitTypeId === FourCC(Units.MercenaryCampNorthrend)
+            || unitTypeId === FourCC(Units.MercenaryCampOutland)
+            || unitTypeId === FourCC(Units.MercenaryCampSunkenRuins)
+            || unitTypeId === FourCC(Units.MercenaryCampUnderground)
+            || unitTypeId === FourCC(Units.MercenaryCampVillage);
+    }
+
+    const buildings: NeutralBuildingData[] = [];
+    const group = CreateGroup();
+
+    GroupEnumUnitsOfPlayer(group, Player(PLAYER_NEUTRAL_PASSIVE), null);
+
+    ForGroup(group, () => {
+        const unit = GetEnumUnit();
+        const unitTypeId = GetUnitTypeId(unit);
+
+        if (!isNeutralStockBuilding(unitTypeId)) {
+            return;
+        }
+
+        buildings.push({
+            unitTypeId,
+            x: GetUnitX(unit),
+            y: GetUnitY(unit),
+            facing: GetUnitFacing(unit),
+        });
+
+        RemoveUnit(unit);
+    });
+
+    DestroyGroup(group);
+
+    for (const building of buildings) {
+        CreateUnit(Player(PLAYER_NEUTRAL_PASSIVE), building.unitTypeId, building.x, building.y, building.facing);
+    }
 }

--- a/src/startGameCountdown.ts
+++ b/src/startGameCountdown.ts
@@ -1,4 +1,5 @@
 import {Timer} from "w3ts";
+import {pauseClockW3C} from "./player_features/clock";
 
 const COUNTDOWN_START = 5;
 const COUNTDOWN_SOUND = CreateSound("Sound\\Interface\\BattleNetTick.wav", false, false, false, 10, 10, "",);
@@ -28,4 +29,5 @@ function onCountdown(count: number) {
 function pauseGameW3C(pause: boolean) {
     PauseAllUnitsBJ(pause);
     SuspendTimeOfDay(pause);
+    pauseClockW3C(pause);
 }

--- a/src/startGameCountdown.ts
+++ b/src/startGameCountdown.ts
@@ -54,7 +54,7 @@ function recreateNeutralStockBuildings() {
         RemoveUnit(unit);
 
         const newUnit = CreateUnit(Player(PLAYER_NEUTRAL_PASSIVE), unitTypeId, unitX, unitY, unitFacing);
-        const teamColorPlayer = NEUTRAL_STOCK_BUILDINGS.get(unitTypeId).teamColorPlayer;
+        const teamColorPlayer = NEUTRAL_STOCK_BUILDINGS.get(unitTypeId);
         if (teamColorPlayer >= 0) {
             SetUnitColor(newUnit, GetPlayerColor(Player(teamColorPlayer)));
         }
@@ -63,42 +63,43 @@ function recreateNeutralStockBuildings() {
     DestroyGroup(group);
 }
 
-// By default, team color of a building is inherited from the owner, but some buildings override that (e.g. Tavern is Red, not Grey).
-// This is only true when creating a building from the map editor, but if creating via a script it always uses Owner color.
-// The color information of a unit is not available at runtime (there is no GetUnitColor()), that is why we store it here.
+// Key: unitTypeId, Value: teamColorPlayer (-1 means inherit color from the owner. >=0 is a player number, e.g., Player 1 (Red) is 0)
 // teamColorPlayer corresponds to "Art - Team Color" (utco) property of an object.
-// -1 means inherit color from the owner. >=0 is a player number, e.g., Player 1 (Red) is 0.
-const NEUTRAL_STOCK_BUILDINGS = new Map<number, { teamColorPlayer: number }>([
-    // [FourCC("ngol"), { teamColorPlayer: -1 }], // Gold Mine
-    [FourCC("ngme"), {teamColorPlayer: -1}], // Goblin Merchant
-    // [FourCC("nfoh"), { teamColorPlayer: -1 }], // Fountain of Health
-    // [FourCC("nmoo"), { teamColorPlayer: -1 }], // Fountain of Mana
-    [FourCC("ngad"), {teamColorPlayer: -1}], // Goblin Laboratory
-    // [FourCC("nwgt"), { teamColorPlayer: -1 }], // Way Gate
-    [FourCC("ndrk"), {teamColorPlayer: -1}], // Black Dragon Roost
-    [FourCC("ndru"), {teamColorPlayer: -1}], // Blue Dragon Roost
-    [FourCC("ndrz"), {teamColorPlayer: -1}], // Bronze Dragon Roost
-    [FourCC("ndrg"), {teamColorPlayer: -1}], // Green Dragon Roost
-    [FourCC("ndro"), {teamColorPlayer: -1}], // Nether Dragon Roost
-    [FourCC("ndrr"), {teamColorPlayer: -1}], // Red Dragon Roost
-    [FourCC("nmer"), {teamColorPlayer: 0}], // Mercenary Camp (Lordaeron Summer)
-    [FourCC("nmr2"), {teamColorPlayer: 12}], // Mercenary Camp (Lordaeron Fall)
-    [FourCC("nmr3"), {teamColorPlayer: 1}], // Mercenary Camp (Lordaeron Winter)
-    [FourCC("nmr4"), {teamColorPlayer: 11}], // Mercenary Camp (Barrens)
-    [FourCC("nmr5"), {teamColorPlayer: 10}], // Mercenary Camp (Ashenvale)
-    [FourCC("nmr6"), {teamColorPlayer: 6}], // Mercenary Camp (Felwood)
-    [FourCC("nmr7"), {teamColorPlayer: 3}], // Mercenary Camp (Northrend)
-    [FourCC("nmr8"), {teamColorPlayer: 9}], // Mercenary Camp (Cityscape)
-    [FourCC("nmr9"), {teamColorPlayer: 8}], // Mercenary Camp (Dalaran)
-    [FourCC("nmr0"), {teamColorPlayer: 5}], // Mercenary Camp (Village)
-    [FourCC("nmra"), {teamColorPlayer: 0}], // Mercenary Camp (Dungeon)
-    [FourCC("nmrb"), {teamColorPlayer: 0}], // Mercenary Camp (Underground)
-    [FourCC("ntav"), {teamColorPlayer: 0}], // Tavern
+//
+// By default, team color of a building is inherited from the owner, but some buildings override that (e.g. Tavern is Red, not Grey).
+// TeamColor property is not respected when creating a unit from a script (it only works when placing a unit from an editor).
+// Also, there is no `GetUnitColor()` like API, that is why we have to store it here.
+const NEUTRAL_STOCK_BUILDINGS = new Map<number, number>([
+    // [FourCC("ngol"), -1 ], // Gold Mine
+    [FourCC("ngme"), -1], // Goblin Merchant
+    // [FourCC("nfoh"), -1 ], // Fountain of Health
+    // [FourCC("nmoo"), -1 ], // Fountain of Mana
+    [FourCC("ngad"), -1], // Goblin Laboratory
+    // [FourCC("nwgt"), -1 ], // Way Gate
+    [FourCC("ndrk"), -1], // Black Dragon Roost
+    [FourCC("ndru"), -1], // Blue Dragon Roost
+    [FourCC("ndrz"), -1], // Bronze Dragon Roost
+    [FourCC("ndrg"), -1], // Green Dragon Roost
+    [FourCC("ndro"), -1], // Nether Dragon Roost
+    [FourCC("ndrr"), -1], // Red Dragon Roost
+    [FourCC("nmer"), 0], // Mercenary Camp (Lordaeron Summer)
+    [FourCC("nmr2"), 12], // Mercenary Camp (Lordaeron Fall)
+    [FourCC("nmr3"), 1], // Mercenary Camp (Lordaeron Winter)
+    [FourCC("nmr4"), 11], // Mercenary Camp (Barrens)
+    [FourCC("nmr5"), 10], // Mercenary Camp (Ashenvale)
+    [FourCC("nmr6"), 6], // Mercenary Camp (Felwood)
+    [FourCC("nmr7"), 3], // Mercenary Camp (Northrend)
+    [FourCC("nmr8"), 9], // Mercenary Camp (Cityscape)
+    [FourCC("nmr9"), 8], // Mercenary Camp (Dalaran)
+    [FourCC("nmr0"), 5], // Mercenary Camp (Village)
+    [FourCC("nmra"), 0], // Mercenary Camp (Dungeon)
+    [FourCC("nmrb"), 0], // Mercenary Camp (Underground)
+    [FourCC("ntav"), 0], // Tavern
     // TODO: Scared to recreate marketplace (there is some initialization code in the maps with them?)
-    // [FourCC("nmrk"), { teamColorPlayer: 0 }], // Marketplace
-    [FourCC("nmrc"), {teamColorPlayer: 1}], // Mercenary Camp (Sunken Ruins)
-    [FourCC("nmrd"), {teamColorPlayer: 9}], // Mercenary Camp (Icecrown Glacier)
-    [FourCC("nshp"), {teamColorPlayer: -1}], // Goblin Shipyard
-    [FourCC("nmre"), {teamColorPlayer: 12}], // Mercenary Camp (Outland)
-    [FourCC("nmrf"), {teamColorPlayer: 3}], // Mercenary Camp (Black Citadel)
+    // [FourCC("nmrk"), 0 ], // Marketplace
+    [FourCC("nmrc"), 1], // Mercenary Camp (Sunken Ruins)
+    [FourCC("nmrd"), 9], // Mercenary Camp (Icecrown Glacier)
+    [FourCC("nshp"), -1], // Goblin Shipyard
+    [FourCC("nmre"), 12], // Mercenary Camp (Outland)
+    [FourCC("nmrf"), 3], // Mercenary Camp (Black Citadel)
 ]);

--- a/src/startGameCountdown.ts
+++ b/src/startGameCountdown.ts
@@ -1,0 +1,31 @@
+import {Timer} from "w3ts";
+
+const COUNTDOWN_START = 5;
+const COUNTDOWN_SOUND = CreateSound("Sound\\Interface\\BattleNetTick.wav", false, false, false, 10, 10, "",);
+
+export function enableStartGameCountdown() {
+    pauseGameW3C(true);
+
+    for (let count = COUNTDOWN_START; count >= 0; count--) {
+        // This is a workaround for Lua.
+        // Passing `count` directly to the callback results in passing a reference that will be 0 at execution time.
+        const cc = count;
+        Timer.create().start(COUNTDOWN_START - count, false, () => onCountdown(cc));
+    }
+}
+
+function onCountdown(count: number) {
+    if (count === 0) {
+        pauseGameW3C(false);
+        ClearTextMessages();
+        return;
+    }
+
+    print(`|cff00ff00[W3C]:|r Starting in ${count}...`);
+    StartSound(COUNTDOWN_SOUND);
+}
+
+function pauseGameW3C(pause: boolean) {
+    PauseAllUnitsBJ(pause);
+    SuspendTimeOfDay(pause);
+}

--- a/src/startGameCountdown.ts
+++ b/src/startGameCountdown.ts
@@ -1,8 +1,7 @@
-import {color, Timer} from "w3ts";
+import {Timer} from "w3ts";
 import {pauseClockW3C} from "./player_features/clock";
-import {Units} from "@objectdata/units";
 
-const COUNTDOWN_START = 10;
+const COUNTDOWN_START = 5;
 const COUNTDOWN_SOUND = CreateSound("Sound\\Interface\\BattleNetTick.wav", false, false, false, 10, 10, "",);
 
 export function enableStartGameCountdown() {
@@ -36,40 +35,6 @@ function pauseGameW3C(pause: boolean) {
 
 // Recreating tavern/shop/merc resets initial stock cooldown delay for heroes/items/units in them
 function recreateNeutralStockBuildings() {
-    interface NeutralBuildingData {
-        unitTypeId: number;
-        x: number;
-        y: number;
-        facing: number;
-        color: number;
-    }
-
-    function isNeutralStockBuilding(unitTypeId: number): boolean {
-        return unitTypeId === FourCC(Units.Tavern)
-            || unitTypeId === FourCC(Units.GoblinMerchant)
-            || unitTypeId === FourCC(Units.Marketplace)
-            || unitTypeId === FourCC(Units.GoblinLaboratory)
-            || unitTypeId === FourCC(Units.MercenaryCampAshenvale)
-            || unitTypeId === FourCC(Units.MercenaryCampBarrens)
-            || unitTypeId === FourCC(Units.MercenaryCampBlackCitadel)
-            || unitTypeId === FourCC(Units.MercenaryCampCityscape)
-            || unitTypeId === FourCC(Units.MercenaryCampDalaran)
-            || unitTypeId === FourCC(Units.MercenaryCampDungeon)
-            || unitTypeId === FourCC(Units.MercenaryCampFelwood)
-            || unitTypeId === FourCC(Units.MercenaryCampIcecrownGlacier)
-            || unitTypeId === FourCC(Units.MercenaryCampLordaeronFall)
-            || unitTypeId === FourCC(Units.MercenaryCampLordaeronSummer)
-            || unitTypeId === FourCC(Units.MercenaryCampLordaeronWinter)
-            || unitTypeId === FourCC(Units.MercenaryCampNorthrend)
-            || unitTypeId === FourCC(Units.MercenaryCampOutland)
-            || unitTypeId === FourCC(Units.MercenaryCampSunkenRuins)
-            || unitTypeId === FourCC(Units.MercenaryCampUnderground)
-            || unitTypeId === FourCC(Units.MercenaryCampVillage);
-        //FIXME: add missing building (dragon roosts, etc)
-        //Check for "Tech tree - Units Sold or Items Sold" Fields
-    }
-
-    const buildings: NeutralBuildingData[] = [];
     const group = CreateGroup();
 
     GroupEnumUnitsOfPlayer(group, Player(PLAYER_NEUTRAL_PASSIVE), null);
@@ -78,67 +43,62 @@ function recreateNeutralStockBuildings() {
         const unit = GetEnumUnit();
         const unitTypeId = GetUnitTypeId(unit);
 
-        if (!isNeutralStockBuilding(unitTypeId)) {
+        if (!NEUTRAL_STOCK_BUILDINGS.has(unitTypeId)) {
             return;
         }
 
-        //"Art - Team Color" property of an object.
-        // if -1 then inherit from the owner.
-        // >=0 player number to inherit color from. For example, 0 for Player 1 (Red)
-        //FIXME: this does not work, make a static table
-        const teamColorPlayer = BlzGetUnitIntegerField(unit, ConvertUnitIntegerField(FourCC('utco')))
-        print(teamColorPlayer)
-        buildings.push({
-            unitTypeId,
-            x: GetUnitX(unit),
-            y: GetUnitY(unit),
-            facing: GetUnitFacing(unit),
-            color: teamColorPlayer,
-        });
+        const unitX = GetUnitX(unit);
+        const unitY = GetUnitY(unit);
+        const unitFacing = GetUnitFacing(unit);
 
         RemoveUnit(unit);
+
+        const newUnit = CreateUnit(Player(PLAYER_NEUTRAL_PASSIVE), unitTypeId, unitX, unitY, unitFacing);
+        const teamColorPlayer = NEUTRAL_STOCK_BUILDINGS.get(unitTypeId).teamColorPlayer;
+        if (teamColorPlayer >= 0) {
+            SetUnitColor(newUnit, GetPlayerColor(Player(teamColorPlayer)));
+        }
     });
 
     DestroyGroup(group);
-
-    for (const building of buildings) {
-        const unit = CreateUnit(Player(PLAYER_NEUTRAL_PASSIVE), building.unitTypeId, building.x, building.y, building.facing);
-        if(building.color >= 0 && building.color < bj_MAX_PLAYERS) {
-            // SetUnitColor(unit, GetPlayerColor(Player(building.color)));
-        }
-    }
 }
 
-/** All Neutral Passive Buildings:
- * ngol (Gold Mine)
- * ngme (Goblin Merchant)
- * nfoh (Fountain of Health)
- * nmoo (Fountain of Mana)
- * ngad (Goblin Laboratory)
- * nwgt (Way Gate)
- * ndrk (Black Dragon Roost)
- * ndru (Blue Dragon Roost)
- * ndrz (Bronze Dragon Roost)
- * ndrg (Green Dragon Roost)
- * ndro (Nether Dragon Roost)
- * ndrr (Red Dragon Roost)
- * nmer (Mercenary Camp (Lordaeron Summer))
- * nmr2 (Mercenary Camp (Lordaeron Fall))
- * nmr3 (Mercenary Camp (Lordaeron Winter))
- * nmr4 (Mercenary Camp (Barrens))
- * nmr5 (Mercenary Camp (Ashenvale))
- * nmr6 (Mercenary Camp (Felwood))
- * nmr7 (Mercenary Camp (Northrend))
- * nmr8 (Mercenary Camp (Cityscape))
- * nmr9 (Mercenary Camp (Dalaran))
- * nmr0 (Mercenary Camp (Village))
- * nmra (Mercenary Camp (Dungeon))
- * nmrb (Mercenary Camp (Underground))
- * ntav (Tavern)
- * nmrk (Marketplace)
- * nmrc (Mercenary Camp (Sunken Ruins))
- * nmrd (Mercenary Camp (Icecrown Glacier))
- * nshp (Goblin Shipyard)
- * nmre (Mercenary Camp (Outland))
- * nmrf (Mercenary Camp (Black Citadel))
- */
+// By default, team color of a building is inherited from the owner, but some buildings override that (e.g. Tavern is Red, not Grey).
+// This is only true when creating a building from the map editor, but if creating via a script it always uses Owner color.
+// The color information of a unit is not available at runtime (there is no GetUnitColor()), that is why we store it here.
+// teamColorPlayer corresponds to "Art - Team Color" (utco) property of an object.
+// -1 means inherit color from the owner. >=0 is a player number, e.g., Player 1 (Red) is 0.
+const NEUTRAL_STOCK_BUILDINGS = new Map<number, { teamColorPlayer: number }>([
+    // [FourCC("ngol"), { teamColorPlayer: -1 }], // Gold Mine
+    [FourCC("ngme"), {teamColorPlayer: -1}], // Goblin Merchant
+    // [FourCC("nfoh"), { teamColorPlayer: -1 }], // Fountain of Health
+    // [FourCC("nmoo"), { teamColorPlayer: -1 }], // Fountain of Mana
+    [FourCC("ngad"), {teamColorPlayer: -1}], // Goblin Laboratory
+    // [FourCC("nwgt"), { teamColorPlayer: -1 }], // Way Gate
+    [FourCC("ndrk"), {teamColorPlayer: -1}], // Black Dragon Roost
+    [FourCC("ndru"), {teamColorPlayer: -1}], // Blue Dragon Roost
+    [FourCC("ndrz"), {teamColorPlayer: -1}], // Bronze Dragon Roost
+    [FourCC("ndrg"), {teamColorPlayer: -1}], // Green Dragon Roost
+    [FourCC("ndro"), {teamColorPlayer: -1}], // Nether Dragon Roost
+    [FourCC("ndrr"), {teamColorPlayer: -1}], // Red Dragon Roost
+    [FourCC("nmer"), {teamColorPlayer: 0}], // Mercenary Camp (Lordaeron Summer)
+    [FourCC("nmr2"), {teamColorPlayer: 12}], // Mercenary Camp (Lordaeron Fall)
+    [FourCC("nmr3"), {teamColorPlayer: 1}], // Mercenary Camp (Lordaeron Winter)
+    [FourCC("nmr4"), {teamColorPlayer: 11}], // Mercenary Camp (Barrens)
+    [FourCC("nmr5"), {teamColorPlayer: 10}], // Mercenary Camp (Ashenvale)
+    [FourCC("nmr6"), {teamColorPlayer: 6}], // Mercenary Camp (Felwood)
+    [FourCC("nmr7"), {teamColorPlayer: 3}], // Mercenary Camp (Northrend)
+    [FourCC("nmr8"), {teamColorPlayer: 9}], // Mercenary Camp (Cityscape)
+    [FourCC("nmr9"), {teamColorPlayer: 8}], // Mercenary Camp (Dalaran)
+    [FourCC("nmr0"), {teamColorPlayer: 5}], // Mercenary Camp (Village)
+    [FourCC("nmra"), {teamColorPlayer: 0}], // Mercenary Camp (Dungeon)
+    [FourCC("nmrb"), {teamColorPlayer: 0}], // Mercenary Camp (Underground)
+    [FourCC("ntav"), {teamColorPlayer: 0}], // Tavern
+    // TODO: Scared to recreate marketplace (there is some initialization code in the maps with them?)
+    // [FourCC("nmrk"), { teamColorPlayer: 0 }], // Marketplace
+    [FourCC("nmrc"), {teamColorPlayer: 1}], // Mercenary Camp (Sunken Ruins)
+    [FourCC("nmrd"), {teamColorPlayer: 9}], // Mercenary Camp (Icecrown Glacier)
+    [FourCC("nshp"), {teamColorPlayer: -1}], // Goblin Shipyard
+    [FourCC("nmre"), {teamColorPlayer: 12}], // Mercenary Camp (Outland)
+    [FourCC("nmrf"), {teamColorPlayer: 3}], // Mercenary Camp (Black Citadel)
+]);


### PR DESCRIPTION
* Pauses daytime
* Freezes units (can't order any commands)
* Recreates stock neutral buildings at countdown end to reset their initial stock cooldowns (reset tavern/shop initial cooldowns)
* Pauses W3Champs clock

Issues:
* Blizz clock is ahead by 5s
* Marketplace initial restock delay (2m) is not adjusted (5s earlier) (see `InitNeutralBuildings()`)
* Some building might appear grey in FoW until revealed (e.g. Tavern roof is Grey until first reveal - then it turns Red)

All maps: https://drive.google.com/drive/folders/17Dv9R1zS3nsT517EPet08Ie8SagknSoN?usp=drive_link